### PR TITLE
Update `calloop` to 0.13.0, and bump version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.65.0"
 [dependencies]
 wayland-client = "0.31.1"
 wayland-backend = "0.3.0"
-calloop = "0.12.1"
+calloop = "0.13.0"
 log = { version = "0.4.19", optional = true }
 rustix = { version = "0.38.4", default-features = false, features = ["std"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "calloop-wayland-source"
 description = "A wayland-rs client event source for callloop"
 repository = "https://github.com/smithay/calloop-wayland-source"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Kirill Chibisov <contact@kchibisov.com>"]
 license = "MIT"


### PR DESCRIPTION
This will need a release for sctk to be able to update calloop.